### PR TITLE
feat: add e2e encryption

### DIFF
--- a/api/handler/share.go
+++ b/api/handler/share.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -43,6 +44,13 @@ type SharedDocument struct {
 
 type ShareHandler struct {
 	db *redis.Client
+}
+
+func init() {
+	_, ok := os.LookupEnv("HOST_URL")
+	if !ok {
+		log.Println("HOST_URL is not defined, consider setting to get a full shareable link!")
+	}
 }
 
 func NewShareHandler(db *redis.Client) *ShareHandler {

--- a/cmd/shareless/main.go
+++ b/cmd/shareless/main.go
@@ -13,10 +13,7 @@ import (
 )
 
 func main() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Println("Failed to load .env file")
-	}
+	godotenv.Load()
 
 	PORT, ok := os.LookupEnv("PORT")
 	if !ok {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -18,7 +18,7 @@ func NewDbClient() *redis.Client {
 	redisClient := redis.NewClient(getRedisConfig())
 
 	if err := redisClient.Ping(context.Background()).Err(); err != nil {
-		log.Fatalf("Error connecting to Redis: %v", err)
+		log.Fatalf("Error connecting to Redis: %+v", err)
 	}
 
 	return redisClient
@@ -28,14 +28,13 @@ func getEnv(key string, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
 	}
+  if _, ok := os.LookupEnv("REDIS_URL"); !ok {
+		log.Printf("%s is not defined, using %s instead\n", key, defaultValue)
+	}
 	return defaultValue
 }
 
 func getHostPortWithDefaults() (string, string, int) {
-	if _, ok := os.LookupEnv("REDIS_URL"); !ok {
-		log.Println("REDIS_URL is not present, using localhost:6379")
-	}
-
 	redisUrl := getEnv("REDIS_URL", "redis://localhost:6379")
 	if !strings.Contains(redisUrl, "://") {
 		redisUrl = "redis://" + redisUrl

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -28,7 +28,7 @@ func getEnv(key string, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
 	}
-  if _, ok := os.LookupEnv("REDIS_URL"); !ok {
+	if _, ok := os.LookupEnv("REDIS_URL"); !ok {
 		log.Printf("%s is not defined, using %s instead\n", key, defaultValue)
 	}
 	return defaultValue

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -5,6 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Shareless - Generate Share Link</title>
     <meta name="description" content="Shareless is an application that enables secure secret sharing without storing the data. Use temporary tokens to access your encrypted secrets.">
+    <meta
+      name="htmx-config"
+      content='{
+        "responseHandling":[
+            {"code":"204", "swap": false},
+            {"code":"[23]..", "swap": true},
+            {"code":"422", "swap": true},
+            {"code":"[45]..", "swap": false, "error":true},
+            {"code":"...", "swap": true}
+        ]
+      }'
+    />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <style>
         body {
@@ -202,7 +214,7 @@
     </nav>
   </header>
   <main class="container">
-    <form id="shareForm" hx-headers='{"Accept": "text/html"}' hx-post="/share" hx-target="#result" hx-swap="innerHTML" hx-ext="json-enc" hx-on::after-request="this.reset()">
+    <form id="shareForm">
       <div class="icon"><i class="fas fa-lock"></i></div>
         <h2>Share Your Secret</h2>
         <label for="secretText">Secret Text:</label>
@@ -222,7 +234,7 @@
             <option value="24h">1 Day</option>
         </select>
 
-        <button type="submit">Generate Link</button>
+        <button hx-post="/share" hx-target="#result" hx-params="not text" hx-swap="innerHTML" hx-ext="encrypt" hx-trigger="click">Generate Link</button>
     </form>
 
     <div id="result" class="result-message"></div>
@@ -241,6 +253,8 @@
       const charCount = document.getElementById('charCount');
       const maxLength = textarea.maxLength;
 
+      let cipherText;
+
       textarea.addEventListener('input', function() {
         const remaining = maxLength - textarea.value.length;
         charCount.textContent = `${remaining} characters remaining`;
@@ -253,10 +267,15 @@
 
           if (!data.url.match(/https?/)) {
             const url = new URL(window.location);
-            const [path, query] = data.url.split("?token=");
-            url.pathname = path;
-            url.search = `?token=${query}`;
+            const [path] = data.url.split("?token=");
+            url.pathname = data.url;
+            url.search = `?token=${encodeURIComponent(cipherText)}`;
             data.url = url;
+          }
+
+          if (typeof data.url === "string") {
+            data.url = new URL(data.url);
+            data.url.search = `?token=${encodeURIComponent(cipherText)}`;
           }
 
           resultDiv.style.display = 'block';
@@ -312,6 +331,73 @@
           console.error('Failed to copy: ', err);
         });
       }
+
+      async function submitForm() {
+        const formValues = htmx.values(htmx.find("#shareForm"))
+
+        const { privateKey, publicKey, encryptedText } = await encrypt(formValues.text);
+
+        cipherText = encryptedText;
+
+        return JSON.stringify({ privateKey, publicKey, duration: formValues.duration, expire_on_opened: formValues.expire_on_opened })
+      }
+
+      async function encrypt(text) {
+        const algorithm = { name: "RSA-OAEP", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256"}
+        const key = await window.crypto.subtle.generateKey(algorithm, true, ["encrypt", "decrypt"]);
+        const publicKey = await crypto.subtle.exportKey("jwk", key.publicKey);
+        const privateKey = await crypto.subtle.exportKey("jwk", key.privateKey);
+
+        const encryptData = {
+          publicKey: btoa(JSON.stringify(publicKey)),
+          privateKey: btoa(JSON.stringify(privateKey)),
+        };
+
+        const encoded = getMessageEncoding(text);
+
+        const encryptedText = await window.crypto.subtle.encrypt(
+          algorithm,
+          key.publicKey,
+          encoded
+        );
+
+        return { ...encryptData, encryptedText: arrayBufferToBase64(encryptedText) };
+      }
+
+      function arrayBufferToBase64(buffer) {
+        let binary = '';
+        const bytes = new Uint8Array(buffer);
+        const len = bytes.byteLength;
+        for (let i = 0; i < len; i++) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+        return window.btoa(binary);
+      }
+
+      function getMessageEncoding(text) {
+        const enc = new TextEncoder();
+        return enc.encode(text);
+      }
+
+      htmx.defineExtension('encrypt', {
+        onEvent: function (name, evt) {
+          console.log(name)
+          if (name === "htmx:configRequest") {
+            evt.detail.headers['Content-Type'] = "application/json"
+          }
+          if (name === "htmx:confirm") {
+            evt.preventDefault()
+            submitForm().then(data => {
+              evt.detail.elt.parameters = data;
+              evt.detail.issueRequest();
+            })
+          }
+        },
+        encodeParameters: function(xhr, parameters, elt) {
+          xhr.overrideMimeType('text/json')
+          return elt.parameters;
+        }
+      })
     </script>
 </body>
 </html>

--- a/web/templates/shared.html
+++ b/web/templates/shared.html
@@ -133,10 +133,9 @@
 <div class="container">
     <div class="secret-card">
       <h2>Your Secret</h2>
-      <textarea class="secret-text" id="secretText" readonly>{{.Text}}</textarea>
-      <button class="copy-button" onclick="copyToClipboard('{{.Text}}')">Copy Secret</button>
+      <textarea class="secret-text" id="secretText" readonly></textarea>
+      <button class="copy-button">Copy Secret</button>
       <div id="popover" class="popover" style="display: none;">Secret copied!</div>
-
     </div>
 </div>
 
@@ -147,6 +146,50 @@
 </footer>
 
 <script>
+    window.addEventListener("load", async () => {
+      const url = new URL(window.location);
+      const token = url.searchParams.get("token");
+      const privateKey = "{{.PrivateKey}}"
+
+      const plainText = await decrypt(token, privateKey);
+
+      const textarea = document.querySelector("#secretText");
+      textarea.textContent = plainText;
+
+      const button = document.querySelector(".copy-button");
+      button.addEventListener("click", () => copyToClipboard(plainText));
+    })
+
+    async function decrypt(encryptedText, key) {
+      const algorithm = { name: "RSA-OAEP", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256"};
+      const privateKeyText = JSON.parse(atob(key));
+      const privateKey = await window.crypto.subtle.importKey("jwk", privateKeyText, algorithm, true, ["decrypt"]);
+
+      const decryptedText = await window.crypto.subtle.decrypt(
+        algorithm,
+        privateKey,
+        base64ToArrayBuffer(encryptedText)
+      );
+
+      return getMessageDecoded(decryptedText);
+    }
+
+    function getMessageDecoded(encoded) {
+      const dec = new TextDecoder();
+      return dec.decode(encoded);
+    }
+
+    function base64ToArrayBuffer(base64) {
+      console.log({ base64 })
+      const binary_string = window.atob(base64);
+      const len = binary_string.length;
+      const bytes = new Uint8Array( len );
+      for (let i = 0; i < len; i++)        {
+          bytes[i] = binary_string.charCodeAt(i);
+      }
+      return bytes.buffer;
+    }
+
     function copyToClipboard(text) {
       navigator.clipboard.writeText(text).then(() => {
           const popover = document.getElementById('popover');


### PR DESCRIPTION
To add more security and confidence, add end-to-end encryption using web crypto api to generate a key pair and send only it to server, so the link shared contains a id of saved server side key pair and the content encrypted by web crypto api, the secret never go from user browser.